### PR TITLE
chore: gitのcacheからtmpディレクトリを除外

### DIFF
--- a/tmp/build-errors.log
+++ b/tmp/build-errors.log
@@ -1,1 +1,0 @@
-exit status 1


### PR DESCRIPTION
## やったこと
git ignoreが正常に効いていなかったので効かせるための差分