### PR TITLE
feat: TodoFormにフォームバリデーションを導入

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "go-practice-app",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.2",
         "@types/axios": "^0.14.0",
         "axios": "^1.6.1",
         "next": "14.0.2",
@@ -116,6 +117,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4544,6 +4553,12 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
       "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
       "dev": true
+    },
+    "@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.13",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,9 @@
         "next": "14.0.2",
         "react": "^18",
         "react-dom": "^18",
-        "swr": "^2.2.4"
+        "react-hook-form": "^7.48.2",
+        "swr": "^2.2.4",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3532,6 +3534,21 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.48.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
+      "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4457,6 +4474,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -6923,6 +6948,12 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-hook-form": {
+      "version": "7.48.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.48.2.tgz",
+      "integrity": "sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==",
+      "requires": {}
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7579,6 +7610,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "next": "14.0.2",
     "react": "^18",
     "react-dom": "^18",
-    "swr": "^2.2.4"
+    "react-hook-form": "^7.48.2",
+    "swr": "^2.2.4",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.2",
     "@types/axios": "^0.14.0",
     "axios": "^1.6.1",
     "next": "14.0.2",

--- a/frontend/src/features/todo/components/TodoForm.tsx
+++ b/frontend/src/features/todo/components/TodoForm.tsx
@@ -1,23 +1,58 @@
 import React from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+const validationSchema = z.object({
+  title: z.string().refine((value) => Boolean(value.trim().length), {
+    message: "タイトルを入力してください",
+  }),
+})
+
+type FormValues = z.infer<typeof validationSchema>
 
 export const TodoForm = () => {
+  const form = useForm<FormValues>({
+    mode: "onChange",
+    resolver: zodResolver(validationSchema),
+  })
+
+  const {
+    register,
+    formState: { errors, isValid },
+  } = form
   return (
     <div
       style={{
         display: "flex",
-        alignItems: "center",
+        alignItems: "flex-start",
         padding: "0 0 1rem",
       }}
     >
-      <input
-        type="text"
-        placeholder="TODOのタイトルを入力してください"
-        style={{
-          marginRight: "2rem",
-          minWidth: "20rem",
-        }}
-      />
-      <button>登録</button>
+      <div>
+        <input
+          {...register("title")}
+          name="title"
+          type="text"
+          placeholder="TODOのタイトルを入力してください"
+          style={{
+            marginRight: "2rem",
+            minWidth: "20rem",
+            display: "block",
+          }}
+        />
+        {errors.title && (
+          <span
+            style={{
+              color: "red",
+              fontSize: "0.75rem",
+            }}
+          >
+            {errors.title?.message}
+          </span>
+        )}
+      </div>
+      <button disabled={!isValid}>登録</button>
     </div>
   )
 }


### PR DESCRIPTION
# やったこと
- TODOのタイトルが必須であることのバリデーション実装(空文字スペース含む)
- バリデーションを突破しない限り登録ボタン押下できない制御
- 上記のための各種パッケージの導入

<img width="888" alt="go-practice-app" src="https://github.com/morieeeenyo/go-practice-app/assets/64336740/c9ef87f7-24bd-444c-9147-24a1a1526030">
